### PR TITLE
fix for arm/disarm command causing disconnect

### DIFF
--- a/flight_data_collect/drone_communication/mavlink_utils.py
+++ b/flight_data_collect/drone_communication/mavlink_utils.py
@@ -42,6 +42,7 @@ def get_mavlink_messages(connect_address):
                 parse_mavlink_msg(msg, mavlink)
             else:
                 timeout_count += 1
+                mavlink = mavutil.mavlink_connection(SERVER_IP + ':' + connect_address)
             send_message_to_clients(json.dumps(msg))
             if timeout_count > 10:
                 send_message_to_clients(json.dumps(


### PR DESCRIPTION
Issue found: The arm/disarm command (and other commands, such as change mode, waypoint, etc.) opens a new mavlink connection using the same UDP port as the one continuously receiving telemetry data. This results in the first connection being overwritten, thus resulting in the disconnect seen.

Fix: When encountering a timeout, the get_mavlink_messages function now reopens the original connection, essentially re-rewriting any potential connection overrides that may have occurred. This is likely the least intrusive fix for the moment.

Notes: In the long run, this may not be desirable. For example, if a sustained MAVLink connection is ever required for a command, this fix would make that command impossible. Solutions may involve requiring two UDP ports per drone, and creating a centralized class/object for managing MAVLink connections.